### PR TITLE
chore: update Go version to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS build
+FROM golang:1.26.4 AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module shadowmere-helper-bot
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.4**.

### Changes
- go.mod: go 1.26.2 → go 1.26.4
- Dockerfile: golang:1.26.2 → golang:1.26.4

_Automated PR by update-go-version.sh_