### PR TITLE
chore: update Go version to 1.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS build
+FROM golang:1.27.0 AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module shadowmere-helper-bot
 
-go 1.26.5
+go 1.27.0
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1


### PR DESCRIPTION
## Go version update

Bumps Go to **1.27.0**.

### Changes
- go.mod: go 1.26.5 → go 1.27.0
- Dockerfile: golang:1.26.5 → golang:1.27.0

_Automated PR by update-go-version.sh_